### PR TITLE
first cut on a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,98 @@
+CODE OF CONDUCT
+===============
+
+KCV Translation Kai is dedicated to providing a harassment-free experience for
+everyone. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all KCV Translation Kai spaces, including chat
+rooms, the github repository and email threads; both online and off. Anyone who
+violates this code of conduct, or its spirit, may be sanctioned or expelled from
+these spaces at the discretion of the community management.
+
+Some KCV Translation Kai spaces may have additional rules in place, which will
+be made clearly available to participants. Participants are responsible for
+knowing and abiding by these rules.
+
+Harassment includes:
+
+* Offensive comments related to gender, gender identity and expression, sexual
+  orientation, disability, mental illness, neuro(a)typicality,
+  physical appearance, body size, age, ethnic background, or religion.
+* Unwelcome comments regarding a person’s lifestyle choices and practices,
+  including those related to food, health, parenting, drugs, and employment.
+* Deliberate misgendering or use of ‘dead’ or rejected names.
+* Gratuitous or off-topic sexual images or behaviour  in spaces where they’re
+  not appropriate.
+* Physical contact and simulated physical contact (eg, textual descriptions like
+  “*hug*” or “*backrub*”) without consent or after a request to stop.
+* Threats of violence.
+* Incitement of violence towards any individual, including encouraging a person
+  to commit suicide or to engage in self-harm.
+* Deliberate intimidation.
+* Stalking or following.
+* Harassing photography or recording, including logging online activity for
+  harassment purposes.
+* Sustained disruption of discussion.
+* Unwelcome sexual attention.
+* Pattern of inappropriate social contact, such as requesting/assuming
+  inappropriate levels of intimacy with others
+* Continued one-on-one communication after requests to cease.
+* Deliberate “outing” of any aspect of a person’s identity without their consent
+  except as necessary to protect vulnerable people from intentional abuse.
+* Publication of non-harassing private communication.
+
+KCV Translation Kai prioritizes marginalized people’s safety over privileged
+people’s comfort. Community management reserves the right not to act on
+complaints regarding:
+
+* ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+* Reasonable communication of boundaries, such as “leave me alone,” “go away,”
+  or “I’m not discussing this with you.”
+* Communicating in a ‘tone’ you don’t find congenial
+* Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or
+  assumptions
+
+Reporting
+---------
+
+If you are being harassed by a member of KCV Translation Kai, notice that
+someone else is being harassed, or have any other concerns, please contact the
+community management at kcvtranslation@gmail.com. If the person who is harassing
+you is on the team, they will recuse themselves from handling your incident.
+
+All complains will be evaluated and acted upon by community management and will
+be responded to as promptly as viable.
+
+This code of conduct applies to KCV Translation Kai spaces, but if you are being
+harassed by a member of KCV Translation Kai outside our spaces, we still want to
+know about it. We will take all good-faith reports of harassment by KCV
+Translation members, especially admins, seriously. This includes harassment
+outside our spaces and harassment that took place at any point in time. The
+abuse team reserves the right to exclude people from KCV Translation Kai based
+on their past behavior, including behavior outside KCV Translation Kai spaces
+and behavior towards people who are not in KCV Translation Kai.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to
+reject any report we believe to have been made in bad faith. Reports intended to
+silence legitimate criticism may be deleted without response.
+
+We will respect confidentiality requests for the purpose of protecting victims
+of abuse. At our discretion, we may publicly name a person about whom we’ve
+received harassment complaints, or privately warn third parties about them, if
+we believe that doing so will increase the safety of KCV Translation Kai members
+or the general public. We will not name harassment victims without their
+affirmative consent.
+
+Consequences
+------------
+
+Participants asked to stop any harassing behavior are expected to comply
+immediately.
+
+If a participant engages in harassing behavior, community management may take
+any action they deem appropriate, up to and including expulsion from all KCV
+Translation spaces and identification of the participant as a harasser to other
+KCV Translation Kai members or the general public.
+
+Any behavior sufficient to merit removal of the individual will also result in
+them being removed from the credits list.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-Kantai Collection Vita Translation
-==================================
+Kantai Collection Vita Translation Kai
+======================================
 
 This is a work in progress project to produce a Kantai Collection Vita
 multilingual translation.
+
+Participants of this project are required to abide by the
+[CODE OF CONDUCT](CODE_OF_CONDUCT.md).
 
 Installing The Translation
 --------------------------


### PR DESCRIPTION
For a number of reasons a code of conduct is a useful addition to this project. The proposed document is an adapatation of the geekfeminism code of conduct, with the following variables used:

COMMUNITY NAME = KCV Translation
RESPONSE TEAM = community management
LEADERSHIP TEAM = admins

As well as a few changes:

- commitment that all complaints are evaluated and acted upon
- clarification that the list is not exclusive and violations of the spirit of the document can also result in action
- any behavior which results in being expelled will also result in their name being removed from the credits
- a reference to racism replaced with "ethnic background"

The email address mentioned is created by me on gmail and will be set up to forward to community management team members. @miyagami will also receive administrative login to the account.

Questions, comments?